### PR TITLE
Correct case for contributor

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 ===Genesis Style Trump===
 
-Contributors: cdils, garyj
+Contributors: cdils, GaryJ
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=AVHE2NBF3FBLW
 Tags: css, style sheet, genesis, genesiswp, studiopress
 Requires at least: 3.8.0


### PR DESCRIPTION
WP.org plugin search results only apparently link the author if the case matches something or other. While my URL is `/garyj/`, I always register as `GaryJ`.